### PR TITLE
Configure capistrano assets deploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,17 +12,23 @@ sql-dump-*.sql
 !.env.example
 
 # Application
+web/app/themes/theme/dist/*
+web/app/themes/theme/bower_components
+web/app/themes/theme/node_modules
+web/app/themes/theme/npm-debug.log
 web/app/plugins
-!web/app/plugins/.gitkeep
 web/app/mu-plugins/*
 web/app/upgrade
 web/app/uploads
 web/media/*
-!web/media/.gitkeep
+
+!web/app/themes/theme/dist/.gitkeep
+!web/app/plugins/.gitkeep
 !web/app/mu-plugins/disallow-indexing.php
 !web/app/mu-plugins/register-theme-directory.php
 !web/app/mu-plugins/bedrock-autoloader.php
 !web/app/mu-plugins/base-setup
+!web/media/.gitkeep
 
 # Vendor (e.g. Composer)
 vendor

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -70,24 +70,23 @@ end
 # Uncomment the following line to run it on deploys if needed
 # after 'deploy:publishing', 'deploy:update_option_paths'
 
-# Compile assets locally, copy assets to production/staging
-
+# Compile assets locally, copy assets to production/staging `dist/` directory
 set :theme_path, Pathname.new('web/app/themes/theme')
-set :local_app_path, Pathname.new('~/Sites/reimaginebelonging/reimaginebelonging.dev')
+set :local_app_path, Pathname.new(File.dirname(__FILE__)).join('../')
 set :local_theme_path, fetch(:local_app_path).join(fetch(:theme_path))
 
 namespace :assets do
   task :compile do
     run_locally do
       within fetch(:local_theme_path) do
-        #execute :gulp, '--production'
+        execute :gulp, '--production'
       end
     end
   end
 
   task :copy do
     on roles(:web) do
-      upload! fetch(:local_theme_path).join('dist').to_s, release_path.join(fetch(:theme_path)), recursive: true
+      upload! fetch(:local_theme_path).join('dist/').to_s, release_path.join(fetch(:theme_path)), recursive: true
     end
   end
 

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -69,3 +69,29 @@ end
 # Note that you need to have WP-CLI installed on your server
 # Uncomment the following line to run it on deploys if needed
 # after 'deploy:publishing', 'deploy:update_option_paths'
+
+# Compile assets locally, copy assets to production/staging
+
+set :theme_path, Pathname.new('web/app/themes/theme')
+set :local_app_path, Pathname.new('~/Sites/reimaginebelonging/reimaginebelonging.dev')
+set :local_theme_path, fetch(:local_app_path).join(fetch(:theme_path))
+
+namespace :assets do
+  task :compile do
+    run_locally do
+      within fetch(:local_theme_path) do
+        #execute :gulp, '--production'
+      end
+    end
+  end
+
+  task :copy do
+    on roles(:web) do
+      upload! fetch(:local_theme_path).join('dist').to_s, release_path.join(fetch(:theme_path)), recursive: true
+    end
+  end
+
+  task deploy: %w(compile copy)
+end
+
+before 'deploy:updated', 'assets:deploy'

--- a/web/app/themes/theme/.gitignore
+++ b/web/app/themes/theme/.gitignore
@@ -1,6 +1,0 @@
-# Include your project-specific ignores in this file
-# Read about how to use .gitignore: https://help.github.com/articles/ignoring-files
-dist
-bower_components
-node_modules
-npm-debug.log


### PR DESCRIPTION
Closes #34

**Adds following tasks to Capistrano**
* `gulp --production` to compile assets into local `dist/` folder
* Copy `dist/` folder to production/staging server

* Copied `theme/.gitignore` rules to projects global `.gitignore` file.
* Removed `theme/.gitignore` 
* Added `theme/dist/.gitkeep` file
