### PR TITLE
Fix source and resource webpage case

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
       "type": "package",
       "package": {
         "name": "advancedcustomfields/acf-pro",
-        "version": "5.2.6",
+        "version": "5.2.7",
         "type": "wordpress-muplugin",
         "dist": {
           "type": "zip",
@@ -69,7 +69,7 @@
     "vlucas/phpdotenv": "1.0.9",
     "johnpbloch/wordpress": "4.2.2",
     "roots/soil": "3.4.0",
-    "advancedcustomfields/acf-pro": "5.2.6",
+    "advancedcustomfields/acf-pro": "5.2.7",
     "roots/wp-h5bp-htaccess": "1.1.0",
     "wpackagist-plugin/password-protected": "2.0"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,11 +4,11 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "85ecc5d0107bd4f3fb2b237fb6543242",
+    "hash": "a46917cd55c87a8e04960128c3e4e684",
     "packages": [
         {
             "name": "advancedcustomfields/acf-pro",
-            "version": "5.2.6",
+            "version": "5.2.7",
             "dist": {
                 "type": "zip",
                 "url": "http://connect.advancedcustomfields.com/index.php?p=pro&a=download&k=b3JkZXJfaWQ9MzYwMTd8dHlwZT1wZXJzb25hbHxkYXRlPTIwMTQtMDctMjkgMDA6MTM6MDg=",

--- a/web/app/mu-plugins/base-setup/custom-fields/group_544a95bb90366.json
+++ b/web/app/mu-plugins/base-setup/custom-fields/group_544a95bb90366.json
@@ -987,7 +987,7 @@
                     "required": 0,
                     "conditional_logic": 0,
                     "wrapper": {
-                        "width": 40,
+                        "width": 30,
                         "class": "",
                         "id": ""
                     },
@@ -996,13 +996,13 @@
                         "book": "Book",
                         "article": "Article (print or online)",
                         "webpage": "Webpage",
-                        "other": "Other"
+                        "other": "Miscellaneous"
                     },
                     "default_value": {
                         "none": "none"
                     },
-                    "multiple": 0,
                     "allow_null": 0,
+                    "multiple": 0,
                     "ui": 0,
                     "ajax": 0,
                     "placeholder": "",
@@ -1040,7 +1040,7 @@
                         ]
                     ],
                     "wrapper": {
-                        "width": 20,
+                        "width": 25,
                         "class": "",
                         "id": ""
                     },
@@ -1070,7 +1070,7 @@
                         ]
                     ],
                     "wrapper": {
-                        "width": 20,
+                        "width": 15,
                         "class": "",
                         "id": ""
                     },
@@ -1099,7 +1099,7 @@
                         ]
                     ],
                     "wrapper": {
-                        "width": 20,
+                        "width": 25,
                         "class": "",
                         "id": ""
                     },
@@ -1112,7 +1112,7 @@
                     "label": "Title",
                     "name": "title",
                     "type": "text",
-                    "instructions": "Note: quotes or formatting will be added automatically",
+                    "instructions": "Enter title",
                     "required": 0,
                     "conditional_logic": [
                         [
@@ -1124,43 +1124,7 @@
                         ]
                     ],
                     "wrapper": {
-                        "width": 40,
-                        "class": "",
-                        "id": ""
-                    },
-                    "default_value": "",
-                    "placeholder": "",
-                    "prepend": "",
-                    "append": "",
-                    "maxlength": "",
-                    "readonly": 0,
-                    "disabled": 0
-                },
-                {
-                    "key": "field_5526a76db3414",
-                    "label": "Periodical or website title",
-                    "name": "periodical_title",
-                    "type": "text",
-                    "instructions": "Example: \"The New Yorker\", \"Reuters\"",
-                    "required": 0,
-                    "conditional_logic": [
-                        [
-                            {
-                                "field": "field_5526a76db340f",
-                                "operator": "==",
-                                "value": "article"
-                            }
-                        ],
-                        [
-                            {
-                                "field": "field_5526a76db340f",
-                                "operator": "==",
-                                "value": "other"
-                            }
-                        ]
-                    ],
-                    "wrapper": {
-                        "width": 30,
+                        "width": 50,
                         "class": "",
                         "id": ""
                     },
@@ -1214,6 +1178,42 @@
                                 "field": "field_5526a76db340f",
                                 "operator": "!=",
                                 "value": "none"
+                            }
+                        ]
+                    ],
+                    "wrapper": {
+                        "width": 20,
+                        "class": "",
+                        "id": ""
+                    },
+                    "default_value": "",
+                    "placeholder": "",
+                    "prepend": "",
+                    "append": "",
+                    "maxlength": "",
+                    "readonly": 0,
+                    "disabled": 0
+                },
+                {
+                    "key": "field_5526a76db3414",
+                    "label": "Periodical or website title",
+                    "name": "periodical_title",
+                    "type": "text",
+                    "instructions": "The New Yorker \/ YouTube",
+                    "required": 0,
+                    "conditional_logic": [
+                        [
+                            {
+                                "field": "field_5526a76db340f",
+                                "operator": "==",
+                                "value": "article"
+                            }
+                        ],
+                        [
+                            {
+                                "field": "field_5526a76db340f",
+                                "operator": "==",
+                                "value": "other"
                             }
                         ]
                     ],
@@ -1272,9 +1272,10 @@
                         "hide": "Collapse all"
                     },
                     "default_value": {
-                        "author": "author"
+                        "": ""
                     },
-                    "layout": "horizontal"
+                    "layout": "horizontal",
+                    "toggle": 0
                 },
                 {
                     "key": "field_5526a76db3412",
@@ -1343,7 +1344,7 @@
                     },
                     "min": 1,
                     "max": "",
-                    "layout": "table",
+                    "layout": "block",
                     "button_label": "+ Add Author",
                     "sub_fields": [
                         {
@@ -1457,7 +1458,7 @@
                     },
                     "min": 1,
                     "max": "",
-                    "layout": "table",
+                    "layout": "block",
                     "button_label": "+ Add Editor",
                     "sub_fields": [
                         {
@@ -1571,7 +1572,7 @@
                     },
                     "min": 1,
                     "max": "",
-                    "layout": "table",
+                    "layout": "block",
                     "button_label": "+ Add Translator",
                     "sub_fields": [
                         {
@@ -1848,7 +1849,15 @@
                     "type": "message",
                     "instructions": "",
                     "required": 0,
-                    "conditional_logic": 0,
+                    "conditional_logic": [
+                        [
+                            {
+                                "field": "field_5526a76db340f",
+                                "operator": "!=",
+                                "value": "none"
+                            }
+                        ]
+                    ],
                     "wrapper": {
                         "width": "",
                         "class": "",
@@ -1901,7 +1910,7 @@
                     "required": 0,
                     "conditional_logic": 0,
                     "wrapper": {
-                        "width": 40,
+                        "width": 30,
                         "class": "",
                         "id": ""
                     },
@@ -1910,7 +1919,7 @@
                         "book": "Book",
                         "article": "Article (print or online)",
                         "webpage": "Webpage",
-                        "other": "Other"
+                        "other": "Miscellaneous"
                     },
                     "default_value": {
                         "none": "none"
@@ -1954,7 +1963,7 @@
                         ]
                     ],
                     "wrapper": {
-                        "width": 20,
+                        "width": 25,
                         "class": "",
                         "id": ""
                     },
@@ -1984,7 +1993,7 @@
                         ]
                     ],
                     "wrapper": {
-                        "width": 20,
+                        "width": 15,
                         "class": "",
                         "id": ""
                     },
@@ -2013,12 +2022,12 @@
                         ]
                     ],
                     "wrapper": {
-                        "width": 20,
+                        "width": 25,
                         "class": "",
                         "id": ""
                     },
-                    "display_format": "d\/m\/Y",
-                    "return_format": "d\/m\/Y",
+                    "display_format": "F j, Y",
+                    "return_format": "F j, Y",
                     "first_day": 1
                 },
                 {
@@ -2038,43 +2047,7 @@
                         ]
                     ],
                     "wrapper": {
-                        "width": 40,
-                        "class": "",
-                        "id": ""
-                    },
-                    "default_value": "",
-                    "placeholder": "",
-                    "prepend": "",
-                    "append": "",
-                    "maxlength": "",
-                    "readonly": 0,
-                    "disabled": 0
-                },
-                {
-                    "key": "field_556b917abb85b",
-                    "label": "Periodical or website title",
-                    "name": "periodical_title",
-                    "type": "text",
-                    "instructions": "Example: \"The New Yorker\", \"Reuters\"",
-                    "required": 0,
-                    "conditional_logic": [
-                        [
-                            {
-                                "field": "field_556b917abb857",
-                                "operator": "==",
-                                "value": "article"
-                            }
-                        ],
-                        [
-                            {
-                                "field": "field_556b917abb857",
-                                "operator": "==",
-                                "value": "other"
-                            }
-                        ]
-                    ],
-                    "wrapper": {
-                        "width": 30,
+                        "width": 50,
                         "class": "",
                         "id": ""
                     },
@@ -2128,6 +2101,42 @@
                                 "field": "field_556b917abb857",
                                 "operator": "!=",
                                 "value": "none"
+                            }
+                        ]
+                    ],
+                    "wrapper": {
+                        "width": 20,
+                        "class": "",
+                        "id": ""
+                    },
+                    "default_value": "",
+                    "placeholder": "",
+                    "prepend": "",
+                    "append": "",
+                    "maxlength": "",
+                    "readonly": 0,
+                    "disabled": 0
+                },
+                {
+                    "key": "field_556b917abb85b",
+                    "label": "Periodical or website title",
+                    "name": "periodical_title",
+                    "type": "text",
+                    "instructions": "The New Yorker \/ YouTube",
+                    "required": 0,
+                    "conditional_logic": [
+                        [
+                            {
+                                "field": "field_556b917abb857",
+                                "operator": "==",
+                                "value": "article"
+                            }
+                        ],
+                        [
+                            {
+                                "field": "field_556b917abb857",
+                                "operator": "==",
+                                "value": "other"
                             }
                         ]
                     ],
@@ -2186,9 +2195,10 @@
                         "hide": "Collapse all"
                     },
                     "default_value": {
-                        "author": "author"
+                        "": ""
                     },
-                    "layout": "horizontal"
+                    "layout": "horizontal",
+                    "toggle": 0
                 },
                 {
                     "key": "field_556b917abb85d",
@@ -2257,7 +2267,7 @@
                     },
                     "min": 1,
                     "max": "",
-                    "layout": "table",
+                    "layout": "block",
                     "button_label": "+ Add Author",
                     "sub_fields": [
                         {
@@ -2371,7 +2381,7 @@
                     },
                     "min": 1,
                     "max": "",
-                    "layout": "table",
+                    "layout": "block",
                     "button_label": "+ Add Editor",
                     "sub_fields": [
                         {
@@ -2485,7 +2495,7 @@
                     },
                     "min": 1,
                     "max": "",
-                    "layout": "table",
+                    "layout": "block",
                     "button_label": "+ Add Translator",
                     "sub_fields": [
                         {
@@ -2552,13 +2562,6 @@
                                 "field": "field_556b917abb857",
                                 "operator": "==",
                                 "value": "article"
-                            }
-                        ],
-                        [
-                            {
-                                "field": "field_556b917abb857",
-                                "operator": "==",
-                                "value": "other"
                             }
                         ]
                     ],
@@ -2711,13 +2714,6 @@
                                 "operator": "==",
                                 "value": "article"
                             }
-                        ],
-                        [
-                            {
-                                "field": "field_556b917abb857",
-                                "operator": "==",
-                                "value": "other"
-                            }
                         ]
                     ],
                     "wrapper": {
@@ -2776,7 +2772,15 @@
                     "type": "message",
                     "instructions": "",
                     "required": 0,
-                    "conditional_logic": 0,
+                    "conditional_logic": [
+                        [
+                            {
+                                "field": "field_556b917abb857",
+                                "operator": "!=",
+                                "value": "none"
+                            }
+                        ]
+                    ],
                     "wrapper": {
                         "width": "",
                         "class": "",
@@ -2815,5 +2819,5 @@
         "tags",
         "send-trackbacks"
     ],
-    "modified": 1435422573
+    "modified": 1435450507
 }

--- a/web/app/themes/theme/assets/ng/events/templates/timeline.event.html
+++ b/web/app/themes/theme/assets/ng/events/templates/timeline.event.html
@@ -129,7 +129,7 @@
               {{ item.location }}:
             </span>
             <span ng-if="item.publisher">
-              {{ item.publisher }},
+              {{ item.publisher }}.
             </span>
             <span ng-if="item.pages">
               {{ siteConfig.event_source_pages }} {{ item.pages }}.
@@ -142,7 +142,7 @@
             </span>
           </span>
 
-          <span ng-switch-when="website">
+          <span ng-switch-when="webpage">
             <span ng-if="item.title">
               "<a href="{{ item.url }}">{{ item.title }}</a>".
             </span>
@@ -263,7 +263,7 @@
               {{ item.location }}:
             </span>
             <span ng-if="item.publisher">
-              {{ item.publisher }},
+              {{ item.publisher }}.
             </span>
             <span ng-if="item.pages">
               {{ siteConfig.event_source_pages }} {{ item.pages }}.
@@ -276,7 +276,7 @@
             </span>
           </span>
 
-          <span ng-switch-when="website">
+          <span ng-switch-when="webpage">
             <span ng-if="item.title">
               "<a href="{{ item.url }}">{{ item.title }}</a>".
             </span>


### PR DESCRIPTION
 - Renamed 'website' case to 'webpage' for sources and resources
 - Fixed coma after publisher source and resource for article output
 - Updated sources and resources fields interface
 - Updated to ACF PRO 5.2.7