### PR TITLE
Fixes and optimizes sources/resources back-end and front-end

### DIFF
--- a/web/app/mu-plugins/base-setup/custom-fields/group_544a95bb90366.json
+++ b/web/app/mu-plugins/base-setup/custom-fields/group_544a95bb90366.json
@@ -973,7 +973,7 @@
                 "class": "",
                 "id": ""
             },
-            "min": 1,
+            "min": "",
             "max": "",
             "layout": "block",
             "button_label": "+ Add Source",
@@ -995,8 +995,8 @@
                         "none": "Select",
                         "book": "Book",
                         "article": "Article (print or online)",
-                        "webpage": "Webpage",
-                        "other": "Miscellaneous"
+                        "website": "Website",
+                        "misc": "Miscellaneous"
                     },
                     "default_value": {
                         "none": "none"
@@ -1035,7 +1035,7 @@
                             {
                                 "field": "field_5526a76db340f",
                                 "operator": "==",
-                                "value": "other"
+                                "value": "misc"
                             }
                         ]
                     ],
@@ -1065,12 +1065,12 @@
                             {
                                 "field": "field_5526a76db340f",
                                 "operator": "!=",
-                                "value": "webpage"
+                                "value": "website"
                             }
                         ]
                     ],
                     "wrapper": {
-                        "width": 15,
+                        "width": 20,
                         "class": "",
                         "id": ""
                     },
@@ -1199,7 +1199,7 @@
                     "label": "Periodical or website title",
                     "name": "periodical_title",
                     "type": "text",
-                    "instructions": "The New Yorker \/ YouTube",
+                    "instructions": "The New Yorker \/ Readymag",
                     "required": 0,
                     "conditional_logic": [
                         [
@@ -1213,7 +1213,7 @@
                             {
                                 "field": "field_5526a76db340f",
                                 "operator": "==",
-                                "value": "other"
+                                "value": "misc"
                             }
                         ]
                     ],
@@ -1232,8 +1232,8 @@
                 },
                 {
                     "key": "field_558f515862d46",
-                    "label": "Webpage name",
-                    "name": "webpage_name",
+                    "label": "Website name",
+                    "name": "website_name",
                     "type": "text",
                     "instructions": "Wikipedia",
                     "required": 0,
@@ -1242,7 +1242,7 @@
                             {
                                 "field": "field_5526a76db340f",
                                 "operator": "==",
-                                "value": "webpage"
+                                "value": "website"
                             }
                         ]
                     ],
@@ -1285,7 +1285,7 @@
                             {
                                 "field": "field_5526a76db340f",
                                 "operator": "==",
-                                "value": "other"
+                                "value": "misc"
                             }
                         ]
                     ],
@@ -1352,7 +1352,7 @@
                             {
                                 "field": "field_5526a76db340f",
                                 "operator": "==",
-                                "value": "other"
+                                "value": "misc"
                             },
                             {
                                 "field": "field_558759e5b7923",
@@ -1371,7 +1371,7 @@
                         "class": "",
                         "id": ""
                     },
-                    "min": 1,
+                    "min": "",
                     "max": "",
                     "layout": "block",
                     "button_label": "+ Add Author",
@@ -1466,7 +1466,7 @@
                             {
                                 "field": "field_5526a76db340f",
                                 "operator": "==",
-                                "value": "other"
+                                "value": "misc"
                             },
                             {
                                 "field": "field_558759e5b7923",
@@ -1485,7 +1485,7 @@
                         "class": "",
                         "id": ""
                     },
-                    "min": 1,
+                    "min": "",
                     "max": "",
                     "layout": "block",
                     "button_label": "+ Add Editor",
@@ -1580,7 +1580,7 @@
                             {
                                 "field": "field_5526a76db340f",
                                 "operator": "==",
-                                "value": "other"
+                                "value": "misc"
                             },
                             {
                                 "field": "field_558759e5b7923",
@@ -1599,7 +1599,7 @@
                         "class": "",
                         "id": ""
                     },
-                    "min": 1,
+                    "min": "",
                     "max": "",
                     "layout": "block",
                     "button_label": "+ Add Translator",
@@ -1710,7 +1710,7 @@
                             {
                                 "field": "field_5526a76db340f",
                                 "operator": "==",
-                                "value": "other"
+                                "value": "misc"
                             }
                         ]
                     ],
@@ -1925,7 +1925,7 @@
                 "class": "",
                 "id": ""
             },
-            "min": "",
+            "min": 0,
             "max": "",
             "layout": "block",
             "button_label": "+ Add Resource",
@@ -1947,8 +1947,8 @@
                         "none": "Select",
                         "book": "Book",
                         "article": "Article (print or online)",
-                        "webpage": "Webpage",
-                        "other": "Miscellaneous"
+                        "website": "Website",
+                        "misc": "Miscellaneous"
                     },
                     "default_value": {
                         "none": "none"
@@ -1987,7 +1987,7 @@
                             {
                                 "field": "field_556b917abb857",
                                 "operator": "==",
-                                "value": "other"
+                                "value": "misc"
                             }
                         ]
                     ],
@@ -2017,12 +2017,12 @@
                             {
                                 "field": "field_556b917abb857",
                                 "operator": "!=",
-                                "value": "webpage"
+                                "value": "website"
                             }
                         ]
                     ],
                     "wrapper": {
-                        "width": 15,
+                        "width": 20,
                         "class": "",
                         "id": ""
                     },
@@ -2151,7 +2151,7 @@
                     "label": "Periodical or website title",
                     "name": "periodical_title",
                     "type": "text",
-                    "instructions": "The New Yorker \/ YouTube",
+                    "instructions": "The New Yorker \/ Readymag",
                     "required": 0,
                     "conditional_logic": [
                         [
@@ -2165,7 +2165,7 @@
                             {
                                 "field": "field_556b917abb857",
                                 "operator": "==",
-                                "value": "other"
+                                "value": "misc"
                             }
                         ]
                     ],
@@ -2184,8 +2184,8 @@
                 },
                 {
                     "key": "field_558f51d662d47",
-                    "label": "Webpage name",
-                    "name": "webpage_name",
+                    "label": "Website name",
+                    "name": "website_name",
                     "type": "text",
                     "instructions": "Wikipedia",
                     "required": 0,
@@ -2194,7 +2194,7 @@
                             {
                                 "field": "field_556b917abb857",
                                 "operator": "==",
-                                "value": "webpage"
+                                "value": "website"
                             }
                         ]
                     ],
@@ -2237,7 +2237,7 @@
                             {
                                 "field": "field_556b917abb857",
                                 "operator": "==",
-                                "value": "other"
+                                "value": "misc"
                             }
                         ]
                     ],
@@ -2304,7 +2304,7 @@
                             {
                                 "field": "field_556b917abb857",
                                 "operator": "==",
-                                "value": "other"
+                                "value": "misc"
                             },
                             {
                                 "field": "field_558c71cbc8425",
@@ -2323,7 +2323,7 @@
                         "class": "",
                         "id": ""
                     },
-                    "min": 1,
+                    "min": "",
                     "max": "",
                     "layout": "block",
                     "button_label": "+ Add Author",
@@ -2418,7 +2418,7 @@
                             {
                                 "field": "field_556b917abb857",
                                 "operator": "==",
-                                "value": "other"
+                                "value": "misc"
                             },
                             {
                                 "field": "field_558c71cbc8425",
@@ -2437,7 +2437,7 @@
                         "class": "",
                         "id": ""
                     },
-                    "min": 1,
+                    "min": "",
                     "max": "",
                     "layout": "block",
                     "button_label": "+ Add Editor",
@@ -2532,7 +2532,7 @@
                             {
                                 "field": "field_556b917abb857",
                                 "operator": "==",
-                                "value": "other"
+                                "value": "misc"
                             },
                             {
                                 "field": "field_558c71cbc8425",
@@ -2551,7 +2551,7 @@
                         "class": "",
                         "id": ""
                     },
-                    "min": 1,
+                    "min": "",
                     "max": "",
                     "layout": "block",
                     "button_label": "+ Add Translator",
@@ -2662,7 +2662,7 @@
                             {
                                 "field": "field_556b917abb857",
                                 "operator": "==",
-                                "value": "other"
+                                "value": "misc"
                             }
                         ]
                     ],
@@ -2877,5 +2877,5 @@
         "tags",
         "send-trackbacks"
     ],
-    "modified": 1435456946
+    "modified": 1436312496
 }

--- a/web/app/themes/theme/assets/ng/events/controllers/event.controller.js
+++ b/web/app/themes/theme/assets/ng/events/controllers/event.controller.js
@@ -54,33 +54,32 @@ angular.module('events.event.controller', [
 
           if ($scope.event.sources) {
             $scope.event.sources.map(function (item) {
-              if (item.author) {
-                item.authors = convertContributors(item.author);
+              if (!item.author) {
+                item.authors = convertContributors(item.author)+'.';
               }
 
-              if (item.editor) {
-                item.editors = convertContributors(item.editor);
+              if (!item.editor) {
+                item.editors = convertContributors(item.editor)+'.';
               }
 
-              if (item.translator) {
-                item.translators = convertContributors(item.translator);
+              if (!item.translator) {
+                item.translators = convertContributors(item.translator)+'.';
               }
             });
           }
 
-
           if ($scope.event.resources) {
             $scope.event.resources.map(function (item) {
-              if (item.author) {
-                item.authors = convertContributors(item.author);
+              if (!item.author) {
+                item.authors = convertContributors(item.author)+'.';
               }
 
-              if (item.editor) {
-                item.editors = convertContributors(item.editor);
+              if (!item.editor) {
+                item.editors = convertContributors(item.editor)+'.';
               }
 
-              if (item.translator) {
-                item.translators = convertContributors(item.translator);
+              if (!item.translator) {
+                item.translators = convertContributors(item.translator)+'.';
               }
             });
           }

--- a/web/app/themes/theme/assets/ng/events/templates/timeline.event.html
+++ b/web/app/themes/theme/assets/ng/events/templates/timeline.event.html
@@ -60,277 +60,357 @@
       </div>
     </div>
     <div class="o-wrapper--row">
-      <h4 class="o-heading c-heading--page-section-title">{{ siteConfig.event_sources_title }}</h4>
-      <!-- Sources -->
-      <ol class="o-list o-list--decimal c-list--page-footnotes">
-        <li ng-repeat="item in event.sources" ng-switch="item.source_type">
-          <span ng-switch-when="book">
-            <span ng-if="item.authors">
-              {{ item.authors }}.
+      <div ng-if="event.sources" class="o-footnotes c-footnotes--sources">
+        <h4 class="o-heading c-heading--page-section-title">{{ siteConfig.event_sources_title }}</h4>
+        <!-- Sources -->
+        <ol class="o-list o-list--decimal c-footnotes__list">
+          <li ng-repeat="item in event.sources" ng-switch="item.source_type" class="c-footnotes__list-item">
+            <span ng-switch-when="book">
+              <span ng-if="item.contributor_type && item.authors">
+                {{ item.authors }}
+              </span>
+              <span ng-if="item.chapter">
+                "{{ item.chapter }}".
+              </span>
+              <span ng-if="item.title && item.url">
+                <em><a href="{{ item.url }}">{{ item.title }}</a></em>.
+              </span>
+              <span ng-if="item.title && !item.url">
+                <em>{{ item.title }}</em>.
+              </span>
+              <span ng-if="item.editors">
+                {{ siteConfig.event_source_editors }} {{ item.editors }}
+              </span>
+              <span ng-if="item.translators">
+                {{ siteConfig.event_source_translators }} {{ item.translators }}
+              </span>
+              <span ng-if="item.edition">
+                {{ siteConfig.event_source_edition}} {{ item.edition }}.
+              </span>
+              <span ng-if="item.volume">
+                {{ siteConfig.event_source_volume }} {{ item.volume }}.
+              </span>
+              <span ng-if="item.location && !item.publisher">
+                {{ item.location }}.
+              </span>
+              <span ng-if="item.location && item.publisher">
+                {{ item.location }}:
+              </span>
+              <span ng-if="item.publisher && !item.date_published && !item.year_published">
+                {{ item.publisher }}.
+              </span>
+              <span ng-if="item.publisher && item.date_published || item.publisher && item.year_published">
+                {{ item.publisher }},
+              </span>
+              <span ng-if="item.date_published">
+                {{ item.date_published }}.
+              </span>
+              <span ng-if="item.year_published && !item.date_published ">
+                {{ item.year_published }}.
+              </span>
+              <span ng-if="item.pages">
+                {{ siteConfig.event_source_pages }} {{ item.pages }}.
+              </span>
+              <span ng-if="item.isbn">
+                {{ item.isbn }}.
+              </span>
             </span>
-            <span ng-if="item.chapter">
-              "<a href="{{ item.url }}">{{ item.chapter }}</a>".
-            </span>
-            <span ng-if="item.title">
-              <em><a href="{{ item.url }}">{{ item.title }}</a></em>.
-            </span>
-            <span ng-if="item.editors">
-              {{ siteConfig.event_source_editors }} {{ item.editors }}.
-            </span>
-            <span ng-if="item.translators">
-              {{ siteConfig.event_source_translators }} {{ item.translators }}.
-            </span>
-            <span ng-if="item.edition">
-              {{ siteConfig.event_source_edition}} {{ item.edition }}.
-            </span>
-            <span ng-if="item.volume">
-              {{ siteConfig.event_source_volume }} {{ item.volume }}.
-            </span>
-            <span ng-if="item.location">
-              {{ item.location }}:
-            </span>
-            <span ng-if="item.publisher">
-              {{ item.publisher }},
-            </span>
-            <span ng-if="item.year_published">
-              {{ item.year_published }}.
-            </span>
-            <span ng-if="item.pages">
-              {{ siteConfig.event_source_pages }} {{ item.pages }}.
-            </span>
-            <span ng-if="item.isbn">
-              {{ item.isbn }}.
-            </span>
-            <span ng-if="item.date_accessed">
-              {{ siteConfig.event_source_date_accessed }}: {{ item.date_accessed }}.
-            </span>
-          </span>
 
-          <span ng-switch-when="article">
-            <span ng-if="item.authors">
-              {{ item.authors }}.
+            <span ng-switch-when="article">
+              <span ng-if="item.authors">
+                {{ item.authors }}
+              </span>
+              <span ng-if="item.title && item.url">
+                "<a href="{{ item.url }}">{{ item.title }}</a>".
+              </span>
+              <span ng-if="item.title && !item.url">
+                "{{ item.title }}".
+              </span>
+              <span ng-if="item.periodical_title">
+                <em>{{ item.periodical_title }}</em>.
+              </span>
+              <span ng-if="item.editors">
+                {{ siteConfig.event_source_editors }} {{ item.editors }}
+              </span>
+              <span ng-if="item.translators">
+                {{ siteConfig.event_source_translators }} {{ item.translators }}
+              </span>
+              <span ng-if="item.edition">
+                {{ siteConfig.event_source_edition}} {{ item.edition }}.
+              </span>
+              <span ng-if="item.location && !item.publisher">
+                {{ item.location }}.
+              </span>
+              <span ng-if="item.location && item.publisher">
+                {{ item.location }}:
+              </span>
+              <span ng-if="item.publisher && !item.date_published && !item.year_published">
+                {{ item.publisher }}.
+              </span>
+              <span ng-if="item.publisher && item.date_published || item.publisher && item.year_published">
+                {{ item.publisher }},
+              </span>
+              <span ng-if="item.date_published">
+                {{ item.date_published }}.
+              </span>
+              <span ng-if="item.year_published && !item.date_published ">
+                {{ item.year_published }}.
+              </span>
+              <span ng-if="item.pages">
+                {{ siteConfig.event_source_pages }} {{ item.pages }}.
+              </span>
+              <span ng-if="item.isbn">
+                {{ item.isbn }}.
+              </span>
+              <span ng-if="item.date_accessed">
+                {{ siteConfig.event_source_date_accessed }}: {{ item.date_accessed }}.
+              </span>
             </span>
-            <span ng-if="item.title">
-              "<a href="{{ item.url }}">{{ item.title }}</a>".
-            </span>
-            <span ng-if="item.periodical_title">
-              <em>{{ item.periodical_title }}</em>.
-            </span>
-            <span ng-if="item.editors">
-              {{ siteConfig.event_source_editors }} {{ item.editors }}.
-            </span>
-            <span ng-if="item.translators">
-              {{ siteConfig.event_source_translators }} {{ item.translators }}.
-            </span>
-            <span ng-if="item.edition">
-              {{ siteConfig.event_source_edition}} {{ item.edition }}.
-            </span>
-            <span ng-if="item.location">
-              {{ item.location }}:
-            </span>
-            <span ng-if="item.publisher">
-              {{ item.publisher }}.
-            </span>
-            <span ng-if="item.pages">
-              {{ siteConfig.event_source_pages }} {{ item.pages }}.
-            </span>
-            <span ng-if="item.isbn">
-              {{ item.isbn }}.
-            </span>
-            <span ng-if="item.date_accessed">
-              {{ siteConfig.event_source_date_accessed }}: {{ item.date_accessed }}.
-            </span>
-          </span>
 
-          <span ng-switch-when="webpage">
-            <span ng-if="item.title">
-              "<a href="{{ item.url }}">{{ item.title }}</a>".
+            <span ng-switch-when="website">
+              <span ng-if="item.title">
+                "<a ng-if="item.url" href="{{ item.url }}">{{ item.title }}</a>".
+              </span>
+              <span ng-if="item.website_name">
+                <em>{{ item.website_name }}</em>.
+              </span>
+              <span ng-if="item.date_accessed">
+                {{ siteConfig.event_source_date_accessed }}: {{ item.date_accessed }}.
+              </span>
             </span>
-            <span ng-if="item.webpage_name">
-              <em>{{ item.webpage_name }}</em>.
-            </span>
-            <span ng-if="item.date_accessed">
-              {{ siteConfig.event_source_date_accessed }}: {{ item.date_accessed }}.
-            </span>
-          </span>
 
-          <span ng-switch-when="other">
-            <span ng-if="item.authors">
-              {{ item.authors }}.
+            <span ng-switch-when="misc">
+              <span ng-if="item.authors">
+                {{ item.authors }}
+              </span>
+              <span ng-if="item.title && item.url">
+                "<a href="{{ item.url }}">{{ item.title }}</a>".
+              </span>
+              <span ng-if="item.title && !item.url">
+                "{{ item.title }}".
+              </span>
+              <span ng-if="item.periodical_title">
+                <em>{{ item.periodical_title }}</em>.
+              </span>
+              <span ng-if="item.editors">
+                {{ siteConfig.event_source_editors }} {{ item.editors }}
+              </span>
+              <span ng-if="item.translators">
+                {{ siteConfig.event_source_translators }} {{ item.translators }}
+              </span>
+              <span ng-if="item.edition">
+                {{ siteConfig.event_source_edition}} {{ item.edition }}.
+              </span>
+              <span ng-if="item.volume">
+                {{ siteConfig.event_source_volume}} {{ item.volume }}.
+              </span>
+              <span ng-if="item.location && !item.publisher">
+                {{ item.location }}.
+              </span>
+              <span ng-if="item.location && item.publisher">
+                {{ item.location }}:
+              </span>
+              <span ng-if="item.publisher && !item.date_published && !item.year_published">
+                {{ item.publisher }}.
+              </span>
+              <span ng-if="item.publisher && item.date_published || item.publisher && item.year_published">
+                {{ item.publisher }},
+              </span>
+              <span ng-if="item.date_published">
+                {{ item.date_published }}.
+              </span>
+              <span ng-if="item.year_published && !item.date_published ">
+                {{ item.year_published }}.
+              </span>
+              <span ng-if="item.pages">
+                {{ siteConfig.event_source_pages }} {{ item.pages }}.
+              </span>
+              <span ng-if="item.isbn">
+                {{ item.isbn }}.
+              </span>
+              <span ng-if="item.date_accessed">
+                {{ siteConfig.event_source_date_accessed }}: {{ item.date_accessed }}.
+              </span>
             </span>
-            <span ng-if="item.title">
-              "<a href="{{ item.url }}">{{ item.title }}</a>".
-            </span>
-            <span ng-if="item.periodical_title">
-              <em>{{ item.periodical_title }}</em>.
-            </span>
-            <span ng-if="item.editors">
-              {{ siteConfig.event_source_editors }} {{ item.editors }}.
-            </span>
-            <span ng-if="item.translators">
-              {{ siteConfig.event_source_translators }} {{ item.translators }}.
-            </span>
-            <span ng-if="item.edition">
-              {{ siteConfig.event_source_edition}} {{ item.edition }}.
-            </span>
-            <span ng-if="item.volume">
-              {{ siteConfig.event_source_volume}} {{ item.volume }}.
-            </span>
-            <span ng-if="item.location">
-              {{ item.location }}:
-            </span>
-            <span ng-if="item.publisher">
-              {{ item.publisher }},
-            </span>
-            <span ng-if="item.pages">
-              {{ siteConfig.event_source_pages }} {{ item.pages }}.
-            </span>
-            <span ng-if="item.isbn">
-              {{ item.isbn }}.
-            </span>
-            <span ng-if="item.date_accessed">
-              {{ siteConfig.event_source_date_accessed }}: {{ item.date_accessed }}.
-            </span>
-          </span>
-        </li>
-      </ol>
-    </div>
+          </li>
+        </ol>
+      </div>
 
-    <div class="o-wrapper--row">
-      <h4 class="o-heading c-heading--page-section-title">{{ siteConfig.event_resources_title }}</h4>
-      <!-- Resources -->
-      <ol class="o-list o-list--decimal c-list--page-footnotes">
-        <li ng-repeat="item in event.resources" ng-switch="item.resource_type">
-          <span ng-switch-when="book">
-            <span ng-if="item.authors">
-              {{ item.authors }}.
+      <div ng-if="event.resources" class="o-footnotes c-footnotes--resources">
+        <h4 class="o-heading c-heading--page-section-title">{{ siteConfig.event_resources_title }}</h4>
+        <!-- Resources -->
+        <ol class="o-list o-list--decimal c-footnotes__list">
+          <li ng-repeat="item in event.resources" ng-switch="item.resource_type" class=" c-footnotes__list-item">
+            <span ng-switch-when="book">
+              <span ng-if="item.authors">
+                {{ item.authors }}
+              </span>
+              <span ng-if="item.chapter">
+                "{{ item.chapter }}".
+              </span>
+              <span ng-if="item.title && item.url">
+                <em><a href="{{ item.url }}">{{ item.title }}</a></em>.
+              </span>
+              <span ng-if="item.title && !item.url">
+                <em>{{ item.title }}</em>.
+              </span>
+              <span ng-if="item.editors">
+                {{ siteConfig.event_source_editors }} {{ item.editors }}
+              </span>
+              <span ng-if="item.translators">
+                {{ siteConfig.event_source_translators }} {{ item.translators }}
+              </span>
+              <span ng-if="item.edition">
+                {{ siteConfig.event_source_edition}} {{ item.edition }}.
+              </span>
+              <span ng-if="item.volume">
+                {{ siteConfig.event_source_volume }} {{ item.volume }}.
+              </span>
+              <span ng-if="item.location && !item.publisher">
+                {{ item.location }}.
+              </span>
+              <span ng-if="item.location && item.publisher">
+                {{ item.location }}:
+              </span>
+              <span ng-if="item.publisher && !item.date_published && !item.year_published">
+                {{ item.publisher }}.
+              </span>
+              <span ng-if="item.publisher && item.date_published || item.publisher && item.year_published">
+                {{ item.publisher }},
+              </span>
+              <span ng-if="item.date_published">
+                {{ item.date_published }}.
+              </span>
+              <span ng-if="item.year_published && !item.date_published ">
+                {{ item.year_published }}.
+              </span>
+              <span ng-if="item.pages">
+                {{ siteConfig.event_source_pages }} {{ item.pages }}.
+              </span>
+              <span ng-if="item.isbn">
+                {{ item.isbn }}.
+              </span>
             </span>
-            <span ng-if="item.chapter">
-              "<a href="{{ item.url }}">{{ item.chapter }}</a>".
-            </span>
-            <span ng-if="item.title">
-              <em><a href="{{ item.url }}">{{ item.title }}</a></em>.
-            </span>
-            <span ng-if="item.editors">
-              {{ siteConfig.event_source_editors }} {{ item.editors }}.
-            </span>
-            <span ng-if="item.translators">
-              {{ siteConfig.event_source_translators }} {{ item.translators }}.
-            </span>
-            <span ng-if="item.edition">
-              {{ siteConfig.event_source_edition}} {{ item.edition }}.
-            </span>
-            <span ng-if="item.volume">
-              {{ siteConfig.event_source_volume }} {{ item.volume }}.
-            </span>
-            <span ng-if="item.location">
-              {{ item.location }}:
-            </span>
-            <span ng-if="item.publisher">
-              {{ item.publisher }},
-            </span>
-            <span ng-if="item.year_published">
-              {{ item.year_published }}.
-            </span>
-            <span ng-if="item.pages">
-              {{ siteConfig.event_source_pages }} {{ item.pages }}.
-            </span>
-            <span ng-if="item.isbn">
-              {{ item.isbn }}.
-            </span>
-            <span ng-if="item.date_accessed">
-              {{ siteConfig.event_source_date_accessed }}: {{ item.date_accessed }}.
-            </span>
-          </span>
 
-          <span ng-switch-when="article">
-            <span ng-if="item.authors">
-              {{ item.authors }}.
+            <span ng-switch-when="article">
+              <span ng-if="item.authors">
+                {{ item.authors }}
+              </span>
+              <span ng-if="item.title && item.url">
+                "<a href="{{ item.url }}">{{ item.title }}</a>".
+              </span>
+              <span ng-if="item.title && !item.url">
+                "{{ item.title }}".
+              </span>
+              <span ng-if="item.periodical_title">
+                <em>{{ item.periodical_title }}</em>.
+              </span>
+              <span ng-if="item.editors">
+                {{ siteConfig.event_source_editors }} {{ item.editors }}
+              </span>
+              <span ng-if="item.translators">
+                {{ siteConfig.event_source_translators }} {{ item.translators }}
+              </span>
+              <span ng-if="item.edition">
+                {{ siteConfig.event_source_edition}} {{ item.edition }}.
+              </span>
+              <span ng-if="item.location && !item.publisher">
+                {{ item.location }}.
+              </span>
+              <span ng-if="item.location && item.publisher">
+                {{ item.location }}:
+              </span>
+              <span ng-if="item.publisher && !item.date_published && !item.year_published">
+                {{ item.publisher }}.
+              </span>
+              <span ng-if="item.publisher && item.date_published || item.publisher && item.year_published">
+                {{ item.publisher }},
+              </span>
+              <span ng-if="item.date_published">
+                {{ item.date_published }}.
+              </span>
+              <span ng-if="item.year_published && !item.date_published ">
+                {{ item.year_published }}.
+              </span>
+              <span ng-if="item.pages">
+                {{ siteConfig.event_source_pages }} {{ item.pages }}.
+              </span>
+              <span ng-if="item.isbn">
+                {{ item.isbn }}.
+              </span>
+              <span ng-if="item.date_accessed">
+                {{ siteConfig.event_source_date_accessed }}: {{ item.date_accessed }}.
+              </span>
             </span>
-            <span ng-if="item.title">
-              "<a href="{{ item.url }}">{{ item.title }}</a>".
-            </span>
-            <span ng-if="item.periodical_title">
-              <em>{{ item.periodical_title }}</em>.
-            </span>
-            <span ng-if="item.editors">
-              {{ siteConfig.event_source_editors }} {{ item.editors }}.
-            </span>
-            <span ng-if="item.translators">
-              {{ siteConfig.event_source_translators }} {{ item.translators }}.
-            </span>
-            <span ng-if="item.edition">
-              {{ siteConfig.event_source_edition}} {{ item.edition }}.
-            </span>
-            <span ng-if="item.location">
-              {{ item.location }}:
-            </span>
-            <span ng-if="item.publisher">
-              {{ item.publisher }}.
-            </span>
-            <span ng-if="item.pages">
-              {{ siteConfig.event_source_pages }} {{ item.pages }}.
-            </span>
-            <span ng-if="item.isbn">
-              {{ item.isbn }}.
-            </span>
-            <span ng-if="item.date_accessed">
-              {{ siteConfig.event_source_date_accessed }}: {{ item.date_accessed }}.
-            </span>
-          </span>
 
-          <span ng-switch-when="webpage">
-            <span ng-if="item.title">
-              "<a href="{{ item.url }}">{{ item.title }}</a>".
+            <span ng-switch-when="website">
+              <span ng-if="item.title">
+                "<a ng-if="item.url" href="{{ item.url }}">{{ item.title }}</a>".
+              </span>
+              <span ng-if="item.website_name">
+                <em>{{ item.website_name }}</em>.
+              </span>
+              <span ng-if="item.date_accessed">
+                {{ siteConfig.event_source_date_accessed }}: {{ item.date_accessed }}.
+              </span>
             </span>
-            <span ng-if="item.webpage_name">
-              <em>{{ item.webpage_name }}</em>.
-            </span>
-            <span ng-if="item.date_accessed">
-              {{ siteConfig.event_source_date_accessed }}: {{ item.date_accessed }}.
-            </span>
-          </span>
 
-          <span ng-switch-when="other">
-            <span ng-if="item.authors">
-              {{ item.authors }}.
+            <span ng-switch-when="misc">
+              <span ng-if="item.authors">
+                {{ item.authors }}
+              </span>
+              <span ng-if="item.title && item.url">
+                "<a href="{{ item.url }}">{{ item.title }}</a>".
+              </span>
+              <span ng-if="item.title && !item.url">
+                "{{ item.title }}".
+              </span>
+              <span ng-if="item.periodical_title">
+                <em>{{ item.periodical_title }}</em>.
+              </span>
+              <span ng-if="item.editors">
+                {{ siteConfig.event_source_editors }} {{ item.editors }}
+              </span>
+              <span ng-if="item.translators">
+                {{ siteConfig.event_source_translators }} {{ item.translators }}
+              </span>
+              <span ng-if="item.edition">
+                {{ siteConfig.event_source_edition}} {{ item.edition }}.
+              </span>
+              <span ng-if="item.volume">
+                {{ siteConfig.event_source_volume}} {{ item.volume }}.
+              </span>
+              <span ng-if="item.location && !item.publisher">
+                {{ item.location }}.
+              </span>
+              <span ng-if="item.location && item.publisher">
+                {{ item.location }}:
+              </span>
+              <span ng-if="item.publisher && !item.date_published && !item.year_published">
+                {{ item.publisher }}.
+              </span>
+              <span ng-if="item.publisher && item.date_published || item.publisher && item.year_published">
+                {{ item.publisher }},
+              </span>
+              <span ng-if="item.date_published">
+                {{ item.date_published }}.
+              </span>
+              <span ng-if="item.year_published && !item.date_published ">
+                {{ item.year_published }}.
+              </span>
+              <span ng-if="item.pages">
+                {{ siteConfig.event_source_pages }} {{ item.pages }}.
+              </span>
+              <span ng-if="item.isbn">
+                {{ item.isbn }}.
+              </span>
+              <span ng-if="item.date_accessed">
+                {{ siteConfig.event_source_date_accessed }}: {{ item.date_accessed }}.
+              </span>
             </span>
-            <span ng-if="item.title">
-              "<a href="{{ item.url }}">{{ item.title }}</a>".
-            </span>
-            <span ng-if="item.periodical_title">
-              <em>{{ item.periodical_title }}</em>.
-            </span>
-            <span ng-if="item.editors">
-              {{ siteConfig.event_source_editors }} {{ item.editors }}.
-            </span>
-            <span ng-if="item.translators">
-              {{ siteConfig.event_source_translators }} {{ item.translators }}.
-            </span>
-            <span ng-if="item.edition">
-              {{ siteConfig.event_source_edition}} {{ item.edition }}.
-            </span>
-            <span ng-if="item.volume">
-              {{ siteConfig.event_source_volume}} {{ item.volume }}.
-            </span>
-            <span ng-if="item.location">
-              {{ item.location }}:
-            </span>
-            <span ng-if="item.publisher">
-              {{ item.publisher }},
-            </span>
-            <span ng-if="item.pages">
-              {{ siteConfig.event_source_pages }} {{ item.pages }}.
-            </span>
-            <span ng-if="item.isbn">
-              {{ item.isbn }}.
-            </span>
-            <span ng-if="item.date_accessed">
-              {{ siteConfig.event_source_date_accessed }}: {{ item.date_accessed }}.
-            </span>
-          </span>
-        </li>
-      </ol>
+          </li>
+        </ol>
+      </div>
     </div>
 
     <ul class="o-wrapper--row">

--- a/web/app/themes/theme/assets/styles/base/lists.styl
+++ b/web/app/themes/theme/assets/styles/base/lists.styl
@@ -3,7 +3,7 @@
   Site text lists
   ===============
 
-  Markup: <ul class="o-list o-list--{modifier} c-list--{modifier}">
+  Markup: <ul class="o-list o-list--{modifier}">
             <li class="o-list_item c-list_item--{modifier}">Item 1</list>
             <li class="o-list_item c-list_item--{modifier}">Item 2</list>
             <li class="o-list_item c-list_item--{modifier}">Item 3</list>
@@ -14,7 +14,6 @@
   list-style-position outside
   margin-left rem(25px)
 
-// List styles
 .o-list--disc
   list-style-type disc
 
@@ -35,14 +34,3 @@
 
 .o-list--lower-alpha
   list-style-type lower-alpha
-
-// Specific cases
-// List of event entry sources and resources
-.c-list--page-footnotes
-  @extend .o-paragraph
-  font-size $size--zeta
-  line-height 1.6
-
-.c-list--page-footnotes li
-  margin-top rem(5px)
-  line-height 1.6

--- a/web/app/themes/theme/assets/styles/components/footnotes.styl
+++ b/web/app/themes/theme/assets/styles/components/footnotes.styl
@@ -1,0 +1,17 @@
+.o-footnotes
+  col(12)
+  +media-query($screen, $bp--desktop)
+    col(6)
+
+.c-footnotes__list
+  @extend .o-paragraph
+  font-size $size--zeta
+  line-height 1.6
+  +media-query($screen, $bp--desktop)
+    font-size $size--epsilon
+
+.c-footnotes__list-item
+  margin-top rem(5px)
+  line-height 1.6
+  +media-query($screen, $bp--desktop)
+    margin-top rem(8px)

--- a/web/app/themes/theme/assets/styles/main.styl
+++ b/web/app/themes/theme/assets/styles/main.styl
@@ -49,3 +49,4 @@ gs("fluid")
 @import 'components/categories-list.styl'
 @import 'components/countries-switcher.styl'
 @import 'components/filter-counter.styl'
+@import 'components/footnotes.styl'


### PR DESCRIPTION
Fixes #150, #151, closes #143, #144
- Adds publishing date to articles
- Renames 'webpage' field to 'website'
- Renames 'other' field to 'misc'
- Fixes empty link on source and resources titles
- Adds conditional logic to sources/resources outputs
- Addresses issue when sources/resources headings were shown even if there is no items
- Split sources and resources list into two columns
- Optimizes footnotes styles and styl files organization
- Other minor fixes